### PR TITLE
Adding Travis CI addon building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+before_install:
+  - "sudo add-apt-repository ppa:koffeinflummi/armake -y"
+  - "sudo apt-get update -q"
+  - "sudo apt-get install armake -y"
+  - "sudo apt-get install sshpass -y"
+script:
+  - "bash -x ./build.sh"
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: 
+      - "echo 'rename incoming/@cnto-assets incoming/@cnto-assets.old\nmkdir incoming/@cnto-assets\nput -r ./@cnto-assets incoming/' | sshpass -e -- sftp -o StrictHostKeyChecking=no cnto-pipeline@repo.carpenoctem.co"
+    on:
+      branch: master

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+declare TARGET_D="@cnto-assets"
+declare SOURCE_D="."
+
+rm -rf ${TARGET_D}
+
+mkdir -p ${TARGET_D}
+for file_name in $(find ${SOURCE_D}/ -mindepth 0 -maxdepth 1 -type f ! -name '.*' ! -name "build.sh")
+do
+  cp "${file_name}" ${TARGET_D}/
+done
+
+mkdir -p ${TARGET_D}/addons
+for file_name in $(find ${SOURCE_D}/addons -mindepth 0 -maxdepth 1 -type f ! -name '.*')
+do
+  cp "${file_name}" ${TARGET_D}/addons
+done
+
+for dir_name in $(find ${SOURCE_D}/addons -mindepth 1 -maxdepth 1 -type d)
+do
+  declare BASE_DIR_NAME=$(basename "$dir_name")
+  armake build -f -p "${dir_name}" "${TARGET_D}/addons/${BASE_DIR_NAME}.pbo"
+done


### PR DESCRIPTION
This PR implements mod building automation, with Travis.ci taking care of building every directory under `./addons` each into a single `.pbo` (using `armake`) as well as uploading the result to the CNTO mod repository for future use by repository maintainers.